### PR TITLE
Add a video club section to the blog

### DIFF
--- a/_data/video_club.yml
+++ b/_data/video_club.yml
@@ -1,0 +1,174 @@
+- presenter: Sandi Metz
+  title: Nothing is Something
+  video_url: https://www.youtube.com/watch?v=9lv2lBq6x4A
+  image_url:
+  note:
+  date: 2017-08-30
+
+- presenter: Dan North
+  title: EventStorming for fun and profit
+  video_url: https://skillsmatter.com/skillscasts/8003-event-storming-for-fun-and-profit
+  image_url:
+  note:
+  date: 2017-09-06
+
+- presenter: Steve Smith
+  title: The death of continuous integration
+  video_url: https://www.infoq.com/presentations/death-continuous-integration
+  image_url:
+  note:
+  date: 2017-09-13
+
+- presenter: Emily Webber
+  title: Communities of Practice, the Missing Piece of Your Agile Organisation
+  video_url: https://www.youtube.com/watch?v=9Owrovki73o
+  image_url:
+  note:
+  date: 2017-09-20
+
+- presenter: Adam Tornhill
+  title: Your code as a crime scene
+  video_url: https://www.youtube.com/watch?v=7FApEq8wum4
+  image_url:
+  note:
+  date: 2017-09-27
+
+- presenter: Jez Humble
+  title: Continuous Delivery In Agile
+  video_url: https://vimeo.com/229954108
+  image_url:
+  note:
+  date: 2017-10-04
+
+- presenter: Dan North
+  title: Patterns of Effective Teams
+  video_url: https://www.youtube.com/watch?v=lvs7VEsQzKY
+  image_url:
+  note:
+  date: 2017-10-11
+
+- presenter: Arif Wider and Christian Deger
+  title: Data Science delivered continuously
+  video_url: https://www.thoughtworks.com/talks/data-science-delivered-continuously-xconf-eu-2017
+  image_url:
+  note:
+  date: 2017-10-11
+
+- presenter: Sarah Mei
+  title: Liveable Code
+  video_url: https://brightonruby.com/2017/livable-code-sarah-mei/
+  image_url:
+  note:
+  date: 2017-10-25
+
+- presenter: Ken Mugrage
+  title: It's not Continuous Delivery if you can't deploy right now
+  video_url: https://www.youtube.com/watch?v=po712VIZZ7M
+  image_url:
+  note:
+  date: 2017-11-01
+
+- presenter: Sallyann Freudenberg
+  title: The Tech Industry needs all Kinds of Minds - How to Support Them?
+  video_url: https://www.youtube.com/watch?v=dvRJmzEoJno
+  image_url:
+  note:
+  date: 2017-11-08
+
+- presenter: Jim Weirich
+  title: Y Not- Adventures in Functional Programming
+  video_url: https://www.youtube.com/watch?v=FITJMJjASUs
+  image_url:
+  note:
+  date: 2017-11-15
+
+- presenter: Jessica Kerr
+  title: Adventures in Elm
+  video_url: https://www.youtube.com/watch?v=cgXhMc8M4X4
+  image_url:
+  note:
+  date: 2017-11-22
+
+- presenter: Jessica Kerr
+  title: Adventures in Elm
+  video_url: https://www.youtube.com/watch?v=cgXhMc8M4X4
+  image_url:
+  note:
+  date: 2017-11-22
+
+- presenter: Gary Bernhardt
+  title: Several Destory All Software Screencasts
+  video_url: https://www.destroyallsoftware.com/screencasts/catalog
+  image_url:
+  note: Gary kindly allowed us to share a few videos from my subscription &#128150;
+  date: 2017-12-06
+
+- presenter: Steve Freeman
+  title: Given When Then considered harmful
+  video_url: https://skillsmatter.com/skillscasts/5009-given-when-then-considered-harmful
+  image_url:
+  note: 
+  date: 2017-12-13
+
+- presenter: Steve Freeman
+  title: Given When Then considered harmful
+  video_url: https://skillsmatter.com/skillscasts/5009-given-when-then-considered-harmful
+  image_url:
+  note: 
+  date: 2017-12-13
+
+- presenter: Hadi Hariri
+  title: intellij tips and tricks
+  video_url: https://www.youtube.com/watch?v=P2MoObVeMX4
+  image_url:
+  note: 
+  date: 2017-12-20
+
+- presenter: Matthew Skelton
+  title: Devops Topologies
+  video_url: https://www.youtube.com/watch?v=K-CXYyMGR6Y&app=desktop
+  image_url:
+  note: 
+  date: 2017-01-03
+
+- presenter: Charity Majors
+  title: Observability for emerging infra
+  video_url: https://www.youtube.com/watch?v=1wjovFSCGhE&app=desktop
+  image_url:
+  note: 
+  date: 2017-01-17
+
+- presenter: Gary Bernhardt
+  title: Boundaries
+  video_url: https://www.destroyallsoftware.com/talks/boundaries
+  image_url:
+  note:
+  date: 2018-01-24
+
+- presenter: Rachel Davies
+  title: XP in the 21st Century
+  video_url: https://www.youtube.com/watch?v=IDKJJDiK3Gw
+  image_url:
+  note: 
+  date: 2017-01-31
+
+- presenter: J. B. Rainsberger
+  title: 7 mins and 26 seconds
+  video_url: https://vimeo.com/79106557
+  image_url:
+  note: 
+  date: 2017-01-31
+
+- presenter: Gwen Shapira
+  title: Stream All Things - Patterns of Modern Data Integration
+  video_url: https://www.youtube.com/watch?v=Hjae0Cw9oew
+  image_url:
+  note: 
+  date: 2017-02-07
+
+- presenter: Dan North
+  title: How to Break the Rules
+  video_url: https://www.youtube.com/watch?v=hZFShSjAhlQ
+  image_url:
+  note: 
+  date: 2017-02-14

--- a/_data/video_club.yml
+++ b/_data/video_club.yml
@@ -110,13 +110,6 @@
   note: 
   date: 2017-12-13
 
-- presenter: Steve Freeman
-  title: Given When Then considered harmful
-  video_url: https://skillsmatter.com/skillscasts/5009-given-when-then-considered-harmful
-  image_url:
-  note: 
-  date: 2017-12-13
-
 - presenter: Hadi Hariri
   title: intellij tips and tricks
   video_url: https://www.youtube.com/watch?v=P2MoObVeMX4
@@ -129,14 +122,14 @@
   video_url: https://www.youtube.com/watch?v=K-CXYyMGR6Y&app=desktop
   image_url:
   note: 
-  date: 2017-01-03
+  date: 2018-01-03
 
 - presenter: Charity Majors
   title: Observability for emerging infra
   video_url: https://www.youtube.com/watch?v=1wjovFSCGhE&app=desktop
   image_url:
   note: 
-  date: 2017-01-17
+  date: 2018-01-17
 
 - presenter: Gary Bernhardt
   title: Boundaries
@@ -150,25 +143,25 @@
   video_url: https://www.youtube.com/watch?v=IDKJJDiK3Gw
   image_url:
   note: 
-  date: 2017-01-31
+  date: 2018-01-31
 
 - presenter: J. B. Rainsberger
   title: 7 mins and 26 seconds
   video_url: https://vimeo.com/79106557
   image_url:
   note: 
-  date: 2017-01-31
+  date: 2018-01-31
 
 - presenter: Gwen Shapira
   title: Stream All Things - Patterns of Modern Data Integration
   video_url: https://www.youtube.com/watch?v=Hjae0Cw9oew
   image_url:
   note: 
-  date: 2017-02-07
+  date: 2018-02-07
 
 - presenter: Dan North
   title: How to Break the Rules
   video_url: https://www.youtube.com/watch?v=hZFShSjAhlQ
   image_url:
   note: 
-  date: 2017-02-14
+  date: 2018-02-14

--- a/_data/video_club.yml
+++ b/_data/video_club.yml
@@ -1,112 +1,105 @@
 - presenter: Sandi Metz
   title: Nothing is Something
   video_url: https://www.youtube.com/watch?v=9lv2lBq6x4A
-  image_url:
+  image_url: https://pbs.twimg.com/media/DIeRd4zUIAAz9Z0.jpg
   note:
   date: 2017-08-30
 
 - presenter: Dan North
   title: EventStorming for fun and profit
   video_url: https://skillsmatter.com/skillscasts/8003-event-storming-for-fun-and-profit
-  image_url:
+  image_url: https://pbs.twimg.com/media/DJCVmgoWsAAQtlK.jpg
   note:
   date: 2017-09-06
 
 - presenter: Steve Smith
   title: The death of continuous integration
   video_url: https://www.infoq.com/presentations/death-continuous-integration
-  image_url:
+  image_url: https://pbs.twimg.com/media/DJmY_xGXkAEPdmp.jpg
   note:
   date: 2017-09-13
 
 - presenter: Emily Webber
   title: Communities of Practice, the Missing Piece of Your Agile Organisation
   video_url: https://www.youtube.com/watch?v=9Owrovki73o
-  image_url:
+  image_url: https://pbs.twimg.com/media/DKKbd8UXUAA4hoZ.jpg
   note:
   date: 2017-09-20
 
 - presenter: Adam Tornhill
   title: Your code as a crime scene
   video_url: https://www.youtube.com/watch?v=7FApEq8wum4
-  image_url:
+  image_url: https://pbs.twimg.com/media/DKueRxhXoAEvYa_.jpg
   note:
   date: 2017-09-27
 
 - presenter: Jez Humble
   title: Continuous Delivery In Agile
   video_url: https://vimeo.com/229954108
-  image_url:
+  image_url: https://pbs.twimg.com/media/DLShnFJXoAE8h6c.jpg
   note:
   date: 2017-10-04
 
 - presenter: Dan North
   title: Patterns of Effective Teams
   video_url: https://www.youtube.com/watch?v=lvs7VEsQzKY
-  image_url:
+  image_url: https://pbs.twimg.com/media/DL2m0HrXkAAhpvW.jpg
   note:
   date: 2017-10-11
 
 - presenter: Arif Wider and Christian Deger
   title: Data Science delivered continuously
   video_url: https://www.thoughtworks.com/talks/data-science-delivered-continuously-xconf-eu-2017
-  image_url:
+  image_url: https://pbs.twimg.com/media/DManpvfW4AAMUwU.jpg
   note:
   date: 2017-10-11
 
 - presenter: Sarah Mei
   title: Liveable Code
   video_url: https://brightonruby.com/2017/livable-code-sarah-mei/
-  image_url:
+  image_url: https://pbs.twimg.com/media/DM_uo4vWkActFhw.jpg
   note:
   date: 2017-10-25
 
 - presenter: Ken Mugrage
   title: It's not Continuous Delivery if you can't deploy right now
   video_url: https://www.youtube.com/watch?v=po712VIZZ7M
-  image_url:
+  image_url: https://pbs.twimg.com/media/DNi9XpXX0AAcQey.jpg
   note:
   date: 2017-11-01
 
 - presenter: Sallyann Freudenberg
   title: The Tech Industry needs all Kinds of Minds - How to Support Them?
   video_url: https://www.youtube.com/watch?v=dvRJmzEoJno
-  image_url:
+  image_url: https://pbs.twimg.com/media/DOHBOrGWsAEcMR6.jpg
   note:
   date: 2017-11-08
 
 - presenter: Jim Weirich
   title: Y Not- Adventures in Functional Programming
   video_url: https://www.youtube.com/watch?v=FITJMJjASUs
-  image_url:
+  image_url: https://pbs.twimg.com/media/DOrEC1qXcAErlyh.jpg
   note:
   date: 2017-11-15
 
 - presenter: Jessica Kerr
   title: Adventures in Elm
   video_url: https://www.youtube.com/watch?v=cgXhMc8M4X4
-  image_url:
-  note:
-  date: 2017-11-22
-
-- presenter: Jessica Kerr
-  title: Adventures in Elm
-  video_url: https://www.youtube.com/watch?v=cgXhMc8M4X4
-  image_url:
+  image_url: https://pbs.twimg.com/media/DPzJaIHW4AU2pqF.jpg
   note:
   date: 2017-11-22
 
 - presenter: Gary Bernhardt
   title: Several Destory All Software Screencasts
   video_url: https://www.destroyallsoftware.com/screencasts/catalog
-  image_url:
+  image_url: https://pbs.twimg.com/media/DQXO-gPXUAEhjmN.jpg
   note: Gary kindly allowed us to share a few videos from my subscription &#128150;
   date: 2017-12-06
 
 - presenter: Steve Freeman
   title: Given When Then considered harmful
   video_url: https://skillsmatter.com/skillscasts/5009-given-when-then-considered-harmful
-  image_url:
+  image_url: https://pbs.twimg.com/media/DQ7VbuiWkAEGuzm.jpg
   note: 
   date: 2017-12-13
 
@@ -120,48 +113,48 @@
 - presenter: Matthew Skelton
   title: Devops Topologies
   video_url: https://www.youtube.com/watch?v=K-CXYyMGR6Y&app=desktop
-  image_url:
+  image_url: https://pbs.twimg.com/media/DSnY3VSW0AAomCF.jpg
   note: 
   date: 2018-01-03
 
 - presenter: Charity Majors
   title: Observability for emerging infra
   video_url: https://www.youtube.com/watch?v=1wjovFSCGhE&app=desktop
-  image_url:
+  image_url: https://pbs.twimg.com/media/DTveFEvXkAA9PpD.jpg
   note: 
   date: 2018-01-17
 
 - presenter: Gary Bernhardt
   title: Boundaries
   video_url: https://www.destroyallsoftware.com/talks/boundaries
-  image_url:
+  image_url: https://pbs.twimg.com/media/DUTiECMW0AEOcCa.jpg
   note:
   date: 2018-01-24
 
 - presenter: Rachel Davies
   title: XP in the 21st Century
   video_url: https://www.youtube.com/watch?v=IDKJJDiK3Gw
-  image_url:
+  image_url: https://pbs.twimg.com/media/DU3lAXLWsAA8zkz.jpg
   note: 
   date: 2018-01-31
 
 - presenter: J. B. Rainsberger
   title: 7 mins and 26 seconds
   video_url: https://vimeo.com/79106557
-  image_url:
+  image_url: https://pbs.twimg.com/media/DU3trFoXkAAMHr6.jpg
   note: 
   date: 2018-01-31
 
 - presenter: Gwen Shapira
   title: Stream All Things - Patterns of Modern Data Integration
   video_url: https://www.youtube.com/watch?v=Hjae0Cw9oew
-  image_url:
+  image_url: https://pbs.twimg.com/media/DVbpfyjWAAAeWKT.jpg
   note: 
   date: 2018-02-07
 
 - presenter: Dan North
   title: How to Break the Rules
   video_url: https://www.youtube.com/watch?v=hZFShSjAhlQ
-  image_url:
+  image_url: https://pbs.twimg.com/media/DV_qkn0XkAA7ZCZ.jpg
   note: 
   date: 2018-02-14

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,6 +28,7 @@
 
           <nav>
             <a href="{{ site.baseurl }}/">Blog</a>
+            <a href="{{ site.baseurl }}/video-club">Video Club</a>
             <a href="{{ site.baseurl }}/about">About</a>
           </nav>
         </header>

--- a/_sass/_video-club.scss
+++ b/_sass/_video-club.scss
@@ -4,7 +4,7 @@
   the coop front end toolkit
 */
 .video-club {
-  article {
+  .video-tile {
     border: solid 1px darkgrey;
     margin-bottom: 15px;
     padding: 15px;

--- a/_sass/_video-club.scss
+++ b/_sass/_video-club.scss
@@ -16,4 +16,10 @@
   h1 {
     margin: 0;
   }
+  .image-footer {
+    margin-top: 15px;
+    margin-left: -15px;
+    margin-right: -15px;
+    margin-bottom: -21px;
+  }
 }

--- a/_sass/_video-club.scss
+++ b/_sass/_video-club.scss
@@ -1,0 +1,19 @@
+
+/* 
+  probably redundant styles once we import 
+  the coop front end toolkit
+*/
+.video-club {
+  article {
+    border: solid 1px darkgrey;
+    margin-bottom: 15px;
+    padding: 15px;
+
+    &:first-of-type {
+      margin-top:15px;
+    }
+  }
+  h1 {
+    margin: 0;
+  }
+}

--- a/style.scss
+++ b/style.scss
@@ -7,6 +7,8 @@
 
 @import "reset";
 @import "variables";
+@import "video-club";
+
 // Syntax highlighting @import is at the bottom of this file
 
 /**************/

--- a/video-club.md
+++ b/video-club.md
@@ -1,0 +1,25 @@
+---
+layout: default
+---
+
+<h1>Video Club</h1>
+<div>
+  Every wednesday we get together to watch a video over lunch.
+</div>
+<div class="video-club">
+  {% for video in site.data.video_club %}
+    <article>
+
+      <h1>{{ video.title }}</h1>
+      <h3>{{ video.presenter }}</h3>
+      <div class="entry">
+        <div class="watched-date">
+          {{ video.date }}
+        </div>
+        <a href="{{ video.video_url }}">
+          watch at: {{ video.video_url }}
+        </a>
+      </div>
+    </article>
+  {% endfor %}
+</div>

--- a/video-club.md
+++ b/video-club.md
@@ -2,10 +2,12 @@
 layout: default
 ---
 
-<h1>Video Club</h1>
-<div>
-  Every wednesday we get together to watch a video over lunch.
-</div>
+# Video Club
+
+Every wednesday we get together to watch a video over lunch.
+
+If you prefer twitter you can [see our tweets about video club there](https://twitter.com/search?f=tweets&q=from%3Apauldambra%20AND%20video%20club%20OR%20%23videoclub&src=typd)
+
 <div class="video-club">
   {% assign sorted_videos = site.data.video_club | sort:"date" | reverse %}
   {% for video in sorted_videos %}
@@ -21,7 +23,13 @@ layout: default
           watch at: {{ video.video_url }}
         </a>
         {% if video.note and video.note != blank %}
-        <p> {{ video.note }} </p>
+          <p> {{ video.note }} </p>
+        {% endif%}
+
+        {% if video.image_url and video.image_url != blank %}
+          <div class="image-footer">
+            <img src="{{ video.image_url }}" />
+          </div>
         {% endif%}
       </div>
     </article>

--- a/video-club.md
+++ b/video-club.md
@@ -11,13 +11,13 @@ If you prefer twitter you can [see our tweets about video club there](https://tw
 <div class="video-club">
   {% assign sorted_videos = site.data.video_club | sort:"date" | reverse %}
   {% for video in sorted_videos %}
-    <article>
+    <div class="video-tile">
 
       <h1>{{ video.title }}</h1>
       <h3>{{ video.presenter }}</h3>
       <div class="entry">
         <div class="watched-date">
-          {{ video.date }}
+          {{ video.date | date: "%d-%m-%Y" }}
         </div>
         <a href="{{ video.video_url }}">
           watch at: {{ video.video_url }}
@@ -28,10 +28,12 @@ If you prefer twitter you can [see our tweets about video club there](https://tw
 
         {% if video.image_url and video.image_url != blank %}
           <div class="image-footer">
-            <img src="{{ video.image_url }}" />
+            <a href="{{ video.video_url }}">
+              <img src="{{ video.image_url }}" />
+            </a>
           </div>
         {% endif%}
       </div>
-    </article>
+    </div>
   {% endfor %}
 </div>

--- a/video-club.md
+++ b/video-club.md
@@ -7,7 +7,8 @@ layout: default
   Every wednesday we get together to watch a video over lunch.
 </div>
 <div class="video-club">
-  {% for video in site.data.video_club %}
+  {% assign sorted_videos = site.data.video_club | sort:"date" | reverse %}
+  {% for video in sorted_videos %}
     <article>
 
       <h1>{{ video.title }}</h1>
@@ -19,6 +20,9 @@ layout: default
         <a href="{{ video.video_url }}">
           watch at: {{ video.video_url }}
         </a>
+        {% if video.note and video.note != blank %}
+        <p> {{ video.note }} </p>
+        {% endif%}
       </div>
     </article>
   {% endfor %}


### PR DESCRIPTION
adds a data yaml file for each video club video we've watched and a page at /video-club that lists them out

lazily hotlinks to twitter images rather than gathering and hosting them here

keeps styling for this page separate so we can migrate it to the coop frontend toolkit or not